### PR TITLE
Do not attempt to match newline characters

### DIFF
--- a/grammars/language-zepto.cson
+++ b/grammars/language-zepto.cson
@@ -54,7 +54,7 @@
     'captures':
       '1':
         'name': 'punctuation.definition.comment.zepto'
-    'match': '(;).*$\\n?'
+    'match': '(;).*$'
     'name': 'comment.line.semicolon.zepto'
   'constants':
     'patterns': [
@@ -115,7 +115,7 @@
     'captures':
       '1':
         'name': 'punctuation.definition.comment.lang.zepto'
-    'match': '^(\\#lang\\s+).*$\\n?'
+    'match': '^(\\#lang\\s+).*$'
     'name': 'comment.line.semicolon.zepto'
   'map':
     'begin': '(#\\{)'
@@ -137,12 +137,10 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.zepto'
-    'end': '(\\))(\\n)?'
+    'end': '(\\))'
     'endCaptures':
       '1':
         'name': 'punctuation.section.expression.end.zepto'
-      '2':
-        'name': 'meta.after-expression.zepto'
     'name': 'meta.quoted-expression.zepto'
     'patterns': [
       {
@@ -154,12 +152,10 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.zepto'
-    'end': '(\\))(\\n)?'
+    'end': '(\\))'
     'endCaptures':
       '1':
         'name': 'punctuation.section.expression.end.zepto'
-      '2':
-        'name': 'meta.after-expression.zepto'
     'name': 'meta.expression.zepto'
     'patterns': [
       {

--- a/spec/language-zepto-spec.coffee
+++ b/spec/language-zepto-spec.coffee
@@ -109,7 +109,7 @@ describe "Zepto grammar", ->
     # Entire expression on one line.
     {tokens} = grammar.tokenizeLine "#{startsWith}foo, bar#{endsWith}"
 
-    [start, mid..., end, after] = tokens
+    [start, mid..., end, whitespace] = tokens
 
     expect(start).toEqual value: startsWith, scopes: ["source.zepto", "meta.#{metaScope}.zepto", "punctuation.section.#{puncScope}.begin.zepto"]
     expect(end).toEqual value: endsWith, scopes: ["source.zepto", "meta.#{metaScope}.zepto", "punctuation.section.#{puncScope}.end.zepto"]
@@ -120,14 +120,14 @@ describe "Zepto grammar", ->
     # Expression broken over multiple lines.
     tokens = grammar.tokenizeLines("#{startsWith}foo\n bar#{endsWith}")
 
-    [start, mid..., after] = tokens[0]
+    [start, mid...] = tokens[0]
 
     expect(start).toEqual value: startsWith, scopes: ["source.zepto", "meta.#{metaScope}.zepto", "punctuation.section.#{puncScope}.begin.zepto"]
 
     for token in mid
       expect(token.scopes.slice(0, 2)).toEqual ["source.zepto", "meta.#{metaScope}.zepto"]
 
-    [mid..., end, after] = tokens[1]
+    [mid..., end] = tokens[1]
 
     expect(end).toEqual value: endsWith, scopes: ["source.zepto", "meta.#{metaScope}.zepto", "punctuation.section.#{puncScope}.end.zepto"]
 


### PR DESCRIPTION
This PR removes optional `\n` matches.  These changes are mainly required due to atom/first-mate#100, as newlines are no longer added to the last line of the file.  Therefore, this change is simply a backwards-compatible change to ensure that language-zepto continues working as before on Atom 1.22+.

/cc @Ingramz

Refs atom/atom#15729